### PR TITLE
Set category attribute to "...starter"

### DIFF
--- a/file-explorer/.metadata
+++ b/file-explorer/.metadata
@@ -5,7 +5,7 @@
 	resources="application.xml" 
 	tags=""
 	type="application" 
-	category="com.marvell.kinoma.examples.fileexplorer">
+	category="com.marvell.kinoma.examples.starter">
 
 	<description><![CDATA[
 This mobile framework example demonstrates how to use the global KPR Files object to iterate local files and directories. The application displays the results in a scrolling list view and provides for deep browsing into nested directories. In addition, previews are supported for image, audio and video files. This example is useful for understanding how to use the Files iterator to iterate over a directory, distinguish between file and directory results, command and screen handler behaviors and building scrolling list based views.


### PR DESCRIPTION
Category must be category="com.marvell.kinoma.examples.starter" for Kinoma Studio to load it in its built-in examples UI.