### PR TITLE
Set category attribute to "...starter"

### DIFF
--- a/tabs/.metadata
+++ b/tabs/.metadata
@@ -5,7 +5,7 @@
 	resources="application.xml" 
 	tags=""
 	type="application" 
-	category="com.marvell.kinoma.examples.tabs">
+	category="com.marvell.kinoma.examples.starter">
 
 	<description><![CDATA[
 This mobile framework example demonstrates how to build a tabbed UI screen. Each tab opens a different style pane. The tabs are placed in the screen footer area and built using the mobile framework screen's TabFooter object and skinned using the default sample theme tab skins. The tab-to-tab transition is managed by the mobile framework TabListSwapTransition. You can customize the tab look and behaviors by replacing and/or overriding these objects. For example, you can use the mobile framework screen's TabLine object to implement a tab bar that can be placed anywhere on the screen and without icons.


### PR DESCRIPTION
Category must be category="com.marvell.kinoma.examples.starter" for Kinoma Studio to load it in its built-in examples UI.