### PR TITLE
Change category to "...starter"

### DIFF
--- a/media-library/.metadata
+++ b/media-library/.metadata
@@ -5,7 +5,7 @@
 	resources="application.xml" 
 	tags=""
 	type="application" 
-	category="com.marvell.kinoma.examples.medialibrary">
+	category="com.marvell.kinoma.examples.starter">
 
 	<description><![CDATA[
 This mobile framework application demonstrates how to access the core media library on iOS, Android and Mac OS platforms to display photos and play media files. The application uses a tabbed view to display photo/video thumbnails and songs. Tapping a media item opens a dedicated media viewer screen. KPR messages are used to request the media items. Note that media library support is not currently available for Kinoma Create or Windows.


### PR DESCRIPTION
Category must be category="com.marvell.kinoma.examples.starter" for Kinoma Studio to load it in its built-in examples UI.