### PR TITLE
update PubNub library so it can work in the SomaFM app

### DIFF
--- a/pubnub/src/pubnub.js
+++ b/pubnub/src/pubnub.js
@@ -3254,6 +3254,7 @@ var pubNubContent = null;
 this.PubNubBehavior = function(content, data) {
 	Behavior.call(this, content, data);
 };
+this.PubNubBehavior.template = Behavior.template;
 this.PubNubBehavior.prototype = Object.create(Behavior.prototype, {
 	onCreate: { value: function(content, data) {
 		pubNubContent = content;

--- a/pubnub/src/unassembled/platform.js
+++ b/pubnub/src/unassembled/platform.js
@@ -252,6 +252,7 @@ var pubNubContent = null;
 this.PubNubBehavior = function(content, data) {
 	Behavior.call(this, content, data);
 };
+this.PubNubBehavior.template = Behavior.template;
 this.PubNubBehavior.prototype = Object.create(Behavior.prototype, {
 	onCreate: { value: function(content, data) {
 		pubNubContent = content;


### PR DESCRIPTION
The SomaFM sample is written using XML. That gets converted to pure JavaScript. The generated code uses templates and expects the PubNubBehavior to support that too. This change patches in the default Behavior.template function to the PubNubBehavior constructor.