### PR TITLE
Replace "cyan" with "aqua"

### DIFF
--- a/kinoma-graph/src/main.xml
+++ b/kinoma-graph/src/main.xml
@@ -232,7 +232,7 @@
 					function draw(canvas) {
 						var ctx = canvas.getContext("2d");
 						ctx.clearRect(0, 0, canvas.width, canvas.height);
-						ctx.fillStyle = this.tracking ? "#00FFFF" : "black";
+						ctx.fillStyle = this.tracking ? "aqua" : "black";
 						if (this.data.playing) {
 							ctx.fillRect(7, 5, 10, 30);
 							ctx.fillRect(23, 5, 10, 30);

--- a/kinoma-graph/src/main.xml
+++ b/kinoma-graph/src/main.xml
@@ -232,7 +232,7 @@
 					function draw(canvas) {
 						var ctx = canvas.getContext("2d");
 						ctx.clearRect(0, 0, canvas.width, canvas.height);
-						ctx.fillStyle = this.tracking ? "cyan" : "black";
+						ctx.fillStyle = this.tracking ? "#00FFFF" : "black";
 						if (this.data.playing) {
 							ctx.fillRect(7, 5, 10, 30);
 							ctx.fillRect(23, 5, 10, 30);


### PR DESCRIPTION
Cyan is a CSS Extended Color Keyword, which is not currently supported in KPR and issues a warning to the console.  Replacing with its hex equivalent #00FFFF.