### PR TITLE
Replace "cyan" with "aqua"

### DIFF
--- a/kinoma-graph/src/main.xml
+++ b/kinoma-graph/src/main.xml
@@ -232,7 +232,7 @@
 					function draw(canvas) {
 						var ctx = canvas.getContext("2d");
 						ctx.clearRect(0, 0, canvas.width, canvas.height);
-						ctx.fillStyle = this.tracking ? "#00FFFF" : "black";
+						ctx.fillStyle = this.tracking ? "aqua" : "black";
 						if (this.data.playing) {
 							ctx.fillRect(7, 5, 10, 30);
 							ctx.fillRect(23, 5, 10, 30);

--- a/kinoma-graph/src/main.xml
+++ b/kinoma-graph/src/main.xml
@@ -232,7 +232,7 @@
 					function draw(canvas) {
 						var ctx = canvas.getContext("2d");
 						ctx.clearRect(0, 0, canvas.width, canvas.height);
-						ctx.fillStyle = this.tracking ? "cyan" : "black";
+						ctx.fillStyle = this.tracking ? "#00FFFF" : "black";
 						if (this.data.playing) {
 							ctx.fillRect(7, 5, 10, 30);
 							ctx.fillRect(23, 5, 10, 30);


### PR DESCRIPTION
Need to define a color keyword that's supported; using 'cyan' (an Extended Color Keyword) is not supported and sends a warning to the console. "Aqua" is a better replacement for "cyan" than "#00FFFF".