### PR TITLE
[oauth] bugfix: need content-type to post data

### DIFF
--- a/oauth/src/twitter.xml
+++ b/oauth/src/twitter.xml
@@ -86,6 +86,7 @@
 		});
 		message.requestText = body;
 		message.setRequestHeader("Content-Length", body.length);
+		message.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 		
 		authorizer.authorize(message, session.requestToken);
 		


### PR DESCRIPTION
Recent Twitter's change of implementation makes the 'Content-Type' header mandatory to post data on body. 