### PR TITLE
Kangaroo Disco: Specify application icon. Layers: Make rectangle more obvious, rearrange sliders for user experience

### DIFF
--- a/i2c-color-sensor/src/main.xml
+++ b/i2c-color-sensor/src/main.xml
@@ -55,7 +55,7 @@
 				colorSensor: {
 					require: "TCS34725",
 					pins: {
-						rgb: { sda: 27, clock: 29, integrationTime: 23 },
+						rgb: { sda: 27, clock: 29 },
 						led: { pin: 21 }
 					}
 				}

--- a/kangaroo-disco/application.xml
+++ b/kangaroo-disco/application.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<application xmlns="http://www.kinoma.com/kpr/application/1" id="kangaroo.disco.example.douzen.com" program="src/main" title="Kangaroo Disco Example">
+<application xmlns="http://www.kinoma.com/kpr/application/1" id="kangaroo.disco.example.douzen.com" program="src/main" title="Kangaroo Disco Example" icon="src/iphone/icon57.png">
 
 </application>

--- a/layers/src/main.js
+++ b/layers/src/main.js
@@ -108,7 +108,7 @@ var Screen = Container.template(function($) { return {
 			contents: [
 				Layer($, { anchor:"LAYER", width:280, height:210, alpha: true,
 					contents: [
-						Container($, { width:280, height:210, skin:new Skin({ fill:"#F0F0F0" }),
+						Container($, { width:280, height:210, skin:new Skin({ fill:"#DDD",borders: { left:3, right:3, top:3, bottom:3 },stroke: 'black',}),
 							contents: [
 								Label($, { style:titleStyle, string: $.title }),
 							],
@@ -175,6 +175,10 @@ var Menu = Column.template(function($) { return {
 			getter: function() { return this.LAYER.opacity * 100 },
 			setter: function(value) { this.LAYER.opacity = value / 100; },
 		}),
+		MenuSlider({ log: false, min: -180, max: 180, step: 1, title: "Rotate",
+			getter: function() { return this.LAYER.rotation },
+			setter: function(value) { this.LAYER.rotation = value ; },
+		}),
 		MenuSlider({ log: false, min: 0, max: 280, step: 1, title: "Origin X",
 			getter: function() { return this.LAYER.origin.x },
 			setter: function(value) { this.LAYER.origin = { x: value }; },
@@ -190,10 +194,6 @@ var Menu = Column.template(function($) { return {
 		MenuSlider({ log: true, min: 10, max: 1000, step: 10, title: "Scale Y",
 			getter: function() { return 100 * this.LAYER.scale.y },
 			setter: function(value) { this.LAYER.scale = { y: value / 100 }; },
-		}),
-		MenuSlider({ log: false, min: -180, max: 180, step: 1, title: "Rotate",
-			getter: function() { return this.LAYER.rotation },
-			setter: function(value) { this.LAYER.rotation = value ; },
 		}),
 		MenuSlider({ log: false, min: -180, max: 180, step: 1, title: "Skew X",
 			getter: function() { return this.LAYER.skew.x },
@@ -414,15 +414,3 @@ MenuTransition.prototype = Object.create(Transition.prototype, {
 		this.menuLayer.translation = this.toolLayer.translation = { x: this.delta * fraction };
 	}}
 });
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Kangaroo Disco: Use iPhone icon as app icon. Demos the use of app icons; looks good when app is installed on Kinoma Create.
Layers: Darkened rectangle and added border to make it more obvious on a Kinoma Create screen.  Moved Rotation slider above Origin sliders so that a user experimenting with sliders one by one from the top down would not encounter sliders that had no obvious effect.