### PR TITLE
Updated to new SENSOR_GAUGE

### DIFF
--- a/serial-7segment-display/simulator/s7s.js
+++ b/serial-7segment-display/simulator/s7s.js
@@ -72,7 +72,7 @@ exports.configure = function(configuration) {
 		header : { 
 			label : this.id, 
 			name : "7-Segment Display", 
-			iconVariant : PinsSimulators.SENSOR_GUAGE 
+			iconVariant : PinsSimulators.SENSOR_GAUGE 
 		},
 		cursor: 0,
 	};


### PR DESCRIPTION
Pins simulators recognize SENSOR_GUAGE and SENSOR_GAUGE as the same variant.  We should use the one that's spelled right.