### PR TITLE
Fix license-simple for debug and export. Typo. Update Zeroconf compatibility info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,7 +1066,7 @@ This example demonstrates how to issue an HTTP request to the OpenWeatherMap ser
 
 <x-app-info id="zeroconf.example.kinoma.marvell.com" platform="mac,iphone,android,linux"><span class="networkSample uiSample"></span></x-app-info>
 
-A simple application that shows Zeroconf usage. The application starts a HTTP server on port 1234, registers it with the name service named "KPR Server". It also looks for available HTTP servers on the local network. Note: Zeroconf is not yet supported on Windows.
+A simple application that shows Zeroconf usage. The application starts a HTTP server on port 1234, registers it with the name service named "KPR Server". It also looks for available HTTP servers on the local network. To run it in the simulators on Windows, first install Apple iTunes. Note: Zeroconf is not yet supported on Linux or Android.
 
 <div style="clear:both; margin-bottom: 16px;"></div>			
 ***

--- a/basic-event-driven-ui/application.xml
+++ b/basic-event-driven-ui/application.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<application xmlns="http://www.kinoma.com/kpr/application/1" id="basiceventdrivenui.example.kinoma.marvell.com" program="src/main" title="Basic Event Drive UI Example">
+<application xmlns="http://www.kinoma.com/kpr/application/1" id="basiceventdrivenui.example.kinoma.marvell.com" program="src/main" title="Basic Event Driven UI Example">
 
 </application>

--- a/license-simple/.modules
+++ b/license-simple/.modules
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modulepath>
    <modulepathentry path="com.marvell.kinoma.kpr:/libraries/MobileFramework.zip" kind="plugin" type="lib"></modulepathentry>
+   <modulepathentry path="src" type="src"></modulepathentry>
 </modulepath>

--- a/zeroconf/.metadata
+++ b/zeroconf/.metadata
@@ -8,7 +8,7 @@
 	category="com.marvell.kinoma.examples.starter">
 
 	<description><![CDATA[
-		A simple application that shows Zeroconf usage. The application starts a HTTP server on port 1234, registers it with the name service named "KPR Server". It also looks for available HTTP servers on the local network. Note: Zeroconf is not yet supported on Windows.
+		A simple application that shows Zeroconf usage. The application starts a HTTP server on port 1234, registers it with the name service named "KPR Server". It also looks for available HTTP servers on the local network. To run it in the simulators on Windows, first install Apple iTunes. Note: Zeroconf is not yet supported on Linux or Android.
 	]]></description>
 
 </example>

--- a/zeroconf/src/main.xml
+++ b/zeroconf/src/main.xml
@@ -171,7 +171,7 @@
 	</container>
 
 	<container id="UnsupportedScreen" left="0" right="0" top="0" bottom="0" skin="blackSkin">
-		<text left="0" right="0" style="errorStyle" string="'This example is not currently supported on Windows.'"/>
+		<text left="0" right="0" style="errorStyle" string="'The Zeroconf extension is not currently supported on Linux or Android.'"/>
 	</container>
 
 	<handler path="/browse">
@@ -205,8 +205,8 @@
 				if (Files.exists(uri)) {
 	                message.status = 200;
 					message.setResponseHeader("Content-Type", "image/jpeg");
-					message.responseBuffer = Files.readBuffer(uri);
-	            	message.setResponseHeader("Content-Length", message.responseBuffer.byteLength);
+					message.responseChunk = Files.readChunk(uri);
+	            	message.setResponseHeader("Content-Length", message.responseChunk.length);
 	            }
 			}
 		]]></behavior>
@@ -248,7 +248,7 @@
 		};
 
 		var model = application.behavior = new ApplicationBehavior(application);
-		if ("win" != system.platform)
+		if ( ("linux" != system.platform) && ("android" != system.platform) )
 			application.add(new BrowserScreen(data));
 		else
 			application.add(new UnsupportedScreen);


### PR DESCRIPTION
* `license-simple` was missing a src modulePathEntry, which prevented it from working properly from Kinoma Studio.

* Basic Event Driven Example was missing an "n"

* Zeroconf actually works on Windows if iTunes is installed, but under no circumstances works on Linux (even with Avahi) or Android.


