### PR TITLE
Libraries to Build Paths

### DIFF
--- a/multitouch-slide-browser/.modules
+++ b/multitouch-slide-browser/.modules
@@ -2,4 +2,5 @@
 <modulepath>
    <modulepathentry path="src" type="src"></modulepathentry>
    <modulepathentry path="com.marvell.kinoma.kpr:/libraries/MultiTouch.zip" kind="plugin" type="lib"></modulepathentry>
+   <modulepathentry path="com.marvell.kinoma.kpr:/libraries/MobileFramework.zip" kind="plugin" type="lib"></modulepathentry>
 </modulepath>

--- a/pubnub/.modules
+++ b/pubnub/.modules
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modulepath>
+   <modulepathentry path="com.marvell.kinoma.kpr:/libraries/MobileFramework.zip" kind="plugin" type="lib"></modulepathentry>
+   <modulepathentry path="com.marvell.kinoma.kpr:/libraries/Controls.zip" kind="plugin" type="lib"></modulepathentry>
    <modulepathentry path="src" type="src"></modulepathentry>
 </modulepath>


### PR DESCRIPTION
PubNub and Multitouch Slide Browser require libraries that were not in their build paths.